### PR TITLE
feature: repo polish — badges, topics, Dependabot, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: site
+
+      - name: Build
+        run: npm run build
+        working-directory: site
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy site
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: '0 8 * * *'
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Adds shields.io badges to README (fixed count, open count, last activity, site status, built with Astro)
- Sets homepage URL and repo description; adds topics (home-maintenance, astro, github-pages, issue-tracker, self-hosted)
- Adds Dependabot config for weekly npm updates on `site/`
- Adds CI workflow that builds the Astro site on every PR to `main`
- Updates all workflow branch references from `master` → `main`

## Test plan

- [ ] CI build passes on this PR
- [ ] Badges render correctly in README preview